### PR TITLE
兼容PHP7.4

### DIFF
--- a/class/SCS.php
+++ b/class/SCS.php
@@ -2273,7 +2273,7 @@ final class SCSRequest
 			elseif ($header == 'Content-Type')
 				$this->response->headers['type'] = $value;
 			elseif ($header == 'ETag')
-				$this->response->headers['hash'] = $value{0} == '"' ? substr($value, 1, -1) : $value;
+				$this->response->headers['hash'] = $value[0] == '"' ? substr($value, 1, -1) : $value;
 			elseif (preg_match('/^x-amz-meta-.*$/', $header))
 				$this->response->headers[$header] = $value;
 		}


### PR DESCRIPTION
PHP 7.4官方已将大括号形式访问字符串 $var{$idx} 指定索引位置的特性去掉，标记为：deprecated，相关文档：
https://www.php.net/manual/zh/migration74.deprecated.php